### PR TITLE
use `cheal-source-map` instead of `source-map`

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -96,7 +96,7 @@ module.exports = (env /*: string */ = 'development', options /*: Options */) => 
   }
 
   // TODO: Fix source-map option in production environment
-  config.devtool = env === 'production' ? false /* 'source-map' */ : 'inline-source-map'
+  config.devtool = env === 'production' ? 'cheap-source-map' : 'inline-source-map'
 
   config.devServer = {}
 


### PR DESCRIPTION
I'm not 100% what the differnce is between these two from the [webpack table](https://webpack.js.org/configuration/devtool/) but I think this should work after the suggestion from [here](https://github.com/webpack-contrib/babel-minify-webpack-plugin/issues/68#issuecomment-344462419).

Related: #6 