### PR TITLE
add 'style' as a main field for imported modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 __generated__/
 dist/
-node_modules/
+/node_modules/
 package-lock.json
 yarn.lock

--- a/examples/css/node_modules/example-package/build/css/index.css
+++ b/examples/css/node_modules/example-package/build/css/index.css
@@ -1,0 +1,3 @@
+.example-button {
+  color: blue;
+}

--- a/examples/css/node_modules/example-package/package.json
+++ b/examples/css/node_modules/example-package/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "example-package",
+  "version": "1.0.0",
+  "description": "A package to use in tests",
+  "style": "build/css/index.css"
+}

--- a/examples/css/src/index.js
+++ b/examples/css/src/index.js
@@ -1,3 +1,4 @@
 import './index.css'
+import 'example-package'
 
 document.body.innerHTML = '<h1>Hello, World!</h1>'

--- a/examples/postcss/node_modules/example-package/build/css/index.css
+++ b/examples/postcss/node_modules/example-package/build/css/index.css
@@ -1,0 +1,3 @@
+.example-button {
+  color: blue;
+}

--- a/examples/postcss/node_modules/example-package/package.json
+++ b/examples/postcss/node_modules/example-package/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "example-package",
+  "version": "1.0.0",
+  "description": "A package to use in tests",
+  "style": "build/css/index.css"
+}

--- a/examples/postcss/src/index.css
+++ b/examples/postcss/src/index.css
@@ -1,3 +1,5 @@
+@import 'example-package';
+
 $red: red;
 
 h1 {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -241,6 +241,10 @@ module.exports = (env /*: string */ = 'development', options /*: Options */) => 
     ]
   }
 
+  config.resolve = {
+    mainFields: ['style', 'browser', 'module', 'main']
+  }
+
   return config
 }
 


### PR DESCRIPTION
Makes us able to import `primer` modules without referencing the absolute path since they all should now have the `style` property set to the compiled CSS.