### PR TITLE
Increase performance limits

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,8 +56,8 @@ const defaultOptions /*: InternalOptions */ = {
   entries: ['index'],
   graphqlProxyPath: '/graphql',
   historyApiFallback: true,
-  maxAssetSize: 200000, // 200 kB
-  maxEntrypointSize: 500000, // 500 kB
+  maxAssetSize: 500000, // 500 kB
+  maxEntrypointSize: 1000000, // 1 mB
   outputPath: './dist',
   srcRoot: './src',
   staticRoot: './public',


### PR DESCRIPTION
It's sad to say, but I think these are the new asset size recommendations for this new tech stack.

Assuming relay + react + react-router, you're looking at a 400kB "frameworks" bundle. This increases that headroom to 500kb for other shared libraries.

With a 500kb baseline, this leaves another 500kb for app code and css. Relay's GraphQL query text easily eat up 50-100Kb on a small app. We should really push for the GitHub API supporting persisted queries so these query text fragments can be replaced with a simple ID at runtime.