### PR TITLE
upgrade relay-compiler-webpack-plugin to 0.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "html-webpack-plugin": "^2.0.0",
     "postcss-loader": "^2.1.0",
     "relay-compiler": "^1.5.0",
-    "relay-compiler-webpack-plugin": "^0.9.0",
+    "relay-compiler-webpack-plugin": "^0.9.2",
     "style-loader": "^0.20.0",
     "webpack": "^3.0.0",
     "webpack-dev-server": "^2.0.0"


### PR DESCRIPTION
Upgrade `relay-compiler-webpack-plugin` to latest version which fixes the issue where it logs to the console constantly.

Closes: https://github.com/github/webpack-config-github/issues/10