### PR TITLE
Allow modifications to CSP

### DIFF
--- a/examples/custom-csp/src/index.js
+++ b/examples/custom-csp/src/index.js
@@ -1,0 +1,1 @@
+document.body.innerHTML = '<h1>Hello, World!</h1>'

--- a/examples/custom-csp/webpack.config.js
+++ b/examples/custom-csp/webpack.config.js
@@ -1,0 +1,11 @@
+/* @flow */
+
+const config = require('../..') // require('webpack-config-github')
+
+module.exports = (env /*: string */) =>
+  config(env, {
+    cspDirectives: {
+      // Allow local fonts and Google fonts
+      fontSrc: ["'self' https://fonts.gstatic.com"]
+    }
+  })

--- a/examples/custom-csp/webpack.config.js
+++ b/examples/custom-csp/webpack.config.js
@@ -2,10 +2,11 @@
 
 const config = require('../..') // require('webpack-config-github')
 
-module.exports = (env /*: string */) =>
-  config(env, {
+module.exports = (env /*: string */) => {
+  return config(env, {
     cspDirectives: {
       // Allow local fonts and Google fonts
       fontSrc: ["'self' https://fonts.gstatic.com"]
     }
   })
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -204,7 +204,8 @@ module.exports = (env /*: string */ = 'development', options /*: Options */) => 
     connectSrc: ["'self'"],
     imgSrc: ["'self'"],
     scriptSrc: ["'self'"],
-    styleSrc: ["'self'", "'unsafe-inline'"]
+    styleSrc: ["'self'", "'unsafe-inline'"],
+    fontSrc: ["'self'"]
   }, opts.cspDirectives || {})
 
   if (opts.allowGitHubSubresources) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -197,16 +197,19 @@ module.exports = (env /*: string */ = 'development', options /*: Options */) => 
     ])
   }
 
-  const directives = Object.assign({
-    defaultSrc: ["'none'"],
-    baseUri: ["'self'"],
-    blockAllMixedContent: true,
-    connectSrc: ["'self'"],
-    imgSrc: ["'self'"],
-    scriptSrc: ["'self'"],
-    styleSrc: ["'self'", "'unsafe-inline'"],
-    fontSrc: ["'self'"]
-  }, opts.cspDirectives || {})
+  const directives = Object.assign(
+    {
+      defaultSrc: ["'none'"],
+      baseUri: ["'self'"],
+      blockAllMixedContent: true,
+      connectSrc: ["'self'"],
+      imgSrc: ["'self'"],
+      scriptSrc: ["'self'"],
+      styleSrc: ["'self'", "'unsafe-inline'"],
+      fontSrc: ["'self'"]
+    },
+    opts.cspDirectives || {}
+  )
 
   if (opts.allowGitHubSubresources) {
     directives.imgSrc.push('*.githubusercontent.com')

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,7 @@ type Options = {|
   srcRoot?: string,
   staticRoot?: string,
   template?: string,
-  cspDirectives?: object
+  cspDirectives?: Object
 |}
 */
 
@@ -49,7 +49,7 @@ type InternalOptions = {|
   srcRoot: string,
   staticRoot: string,
   template: string,
-  cspDirectives: object
+  cspDirectives: Object
 |}
 */
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,7 @@ type Options = {|
   srcRoot?: string,
   staticRoot?: string,
   template?: string,
+  cspDirectives?: object
 |}
 */
 
@@ -47,7 +48,8 @@ type InternalOptions = {|
   outputPath: string,
   srcRoot: string,
   staticRoot: string,
-  template: string
+  template: string,
+  cspDirectives: object
 |}
 */
 
@@ -62,7 +64,8 @@ const defaultOptions /*: InternalOptions */ = {
   outputPath: './dist',
   srcRoot: './src',
   staticRoot: './public',
-  template: path.resolve(__dirname, 'index.html')
+  template: path.resolve(__dirname, 'index.html'),
+  cspDirectives: {}
 }
 
 module.exports = (env /*: string */ = 'development', options /*: Options */) => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -197,7 +197,7 @@ module.exports = (env /*: string */ = 'development', options /*: Options */) => 
     ])
   }
 
-  const directives = {
+  const directives = Object.assign({
     defaultSrc: ["'none'"],
     baseUri: ["'self'"],
     blockAllMixedContent: true,
@@ -205,7 +205,7 @@ module.exports = (env /*: string */ = 'development', options /*: Options */) => 
     imgSrc: ["'self'"],
     scriptSrc: ["'self'"],
     styleSrc: ["'self'", "'unsafe-inline'"]
-  }
+  }, opts.cspDirectives || {})
 
   if (opts.allowGitHubSubresources) {
     directives.imgSrc.push('*.githubusercontent.com')


### PR DESCRIPTION
I've had a couple of situations where I've needed to modify the CSP directives.  Recently I needed to add a `fontSrc` directive to allow for loading local, custom fonts.  This PR adds a default `fontSrc` of `self` and also allows you to pass in a `cspDirectives` option which will let you customize any of the default CSP directives.  

LMK if you'd prefer a different approach or naming.  Also happy to document this.

/cc @josh 