### PR TITLE
fix uncommented flow definition

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -147,7 +147,8 @@ module.exports = (env /*: string */ = 'development', options /*: Options */) => 
     if (process.env.PORT) config.devServer.port = process.env.PORT
 
     if (opts.historyApiFallback) {
-      const rewrites = Object.keys(config.entry).map<{from: string, to: string}>(entry => {
+      // $FlowFixMe
+      const rewrites = Object.keys(config.entry).map(entry => {
         return {from: `/${entry}`, to: `/${entry}.html`}
       })
       config.devServer.historyApiFallback = {rewrites}


### PR DESCRIPTION
I didn't realize in #24 that we use flow ["Comment Types"](https://flow.org/en/docs/types/comments/) and so projects that use `0.10.0` of `webpack-config-github` fail building since they can't parse the flow comments.