### PR TITLE
allow users to pass in their own `resolve` field

### DIFF
--- a/examples/mjs/index.js
+++ b/examples/mjs/index.js
@@ -1,0 +1,3 @@
+const subject = require('./lib')
+
+document.body.innerHTML = `<h1>Hello, ${subject}!</h1>`

--- a/examples/mjs/lib.mjs
+++ b/examples/mjs/lib.mjs
@@ -1,0 +1,1 @@
+export default 'world'

--- a/examples/mjs/webpack.config.js
+++ b/examples/mjs/webpack.config.js
@@ -1,0 +1,5 @@
+/* @flow strict */
+
+const config = require('../..') // require('webpack-config-github')
+
+module.exports = config

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -287,6 +287,7 @@ module.exports = (env /*: string */ = 'development', options /*: Options */) => 
   }
 
   config.resolve = {
+    extensions: ['.mjs', '.js'],
     mainFields: ['style', 'browser', 'module', 'main']
   }
 


### PR DESCRIPTION
[`react-relay-networkd-modern`](https://github.com/relay-tools/react-relay-network-modern) needs to read `.mjs` for some reason. And I would like to use it in my project. The README instructs me to add this to my webpack config but `webpack-config-github` doesn't read it:

```sh
resolve: {
 extensions: ['.mjs', '.js']
}
```

This patch allows users of this package to pass in a `resolve` value and will make sure `resolve.mainFields` includes the correct values in addition to whatever the user supplied.