### PR TITLE
Update `relay-compiler` to 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "html-webpack-plugin": "^3.2.0",
     "postcss-loader": "^2.1.0",
     "read-pkg": "^3.0.0",
-    "relay-compiler": "^1.5.0",
+    "relay-compiler": "^1.6.0",
     "relay-compiler-webpack-plugin": "^0.9.2",
     "style-loader": "^0.20.0",
     "webpack": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "html-webpack-plugin": "^3.2.0",
     "postcss-loader": "^2.1.0",
     "read-pkg": "^3.0.0",
-    "relay-compiler": "^1.6.0",
-    "relay-compiler-webpack-plugin": "^0.9.2",
+    "relay-compiler": "^1.7.0",
+    "relay-compiler-webpack-plugin": "^1.0.1",
     "style-loader": "^0.20.0",
     "webpack": "^3.0.0",
     "webpack-dev-server": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@babel/preset-react": "^7.0.0",
-    "babel-plugin-relay": "^1.5.0",
+    "babel-plugin-relay": "^1.7.0",
     "eslint": "^4.11.0",
     "eslint-plugin-github": "^0.25.0",
     "flow-bin": "^0.83.0",


### PR DESCRIPTION
I'm hoping this will fix the test failures happening on #27 and #28.