### PR TITLE
Use fork of package with relay-compiler@2 installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "postcss-loader": "^2.1.0",
     "read-pkg": "^3.0.0",
     "relay-compiler": "^1.5.0",
-    "relay-compiler-webpack-plugin": "^0.9.2",
+    "relay-compiler-webpack-plugin": "git://github.com/koddsson/relay-compiler-webpack-plugin.git#relay-compiler-2",
     "style-loader": "^0.20.0",
     "webpack": "^3.0.0",
     "webpack-dev-server": "^2.0.0"


### PR DESCRIPTION
Update to my fork of `relay-compiler-webpack-plugin` that has `relay-compiler@2.0.0-rc.1` installed instead of `relay-compiler@1.7.0`. Version `2.0.0-rc-1` updates `graphql` to version 14 which gets us out of some messed up dependency hell since `graphql` likes to have only one instance of itself in `node_module`.